### PR TITLE
Add App Router API endpoints

### DIFF
--- a/src/app/api/matches/[id]/route.ts
+++ b/src/app/api/matches/[id]/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '../../../../lib/prisma';
+
+export async function GET(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  const id = Number(params.id);
+
+  if (Number.isNaN(id)) {
+    return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
+  }
+
+  try {
+    const match = await prisma.match.findUnique({
+      where: { id },
+      include: {
+        player1: true,
+        player2: true,
+        winner: true,
+        tournament: true,
+      },
+    });
+
+    if (!match) {
+      return NextResponse.json({ error: 'Match not found' }, { status: 404 });
+    }
+
+    return NextResponse.json(match);
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/api/matches/route.ts
+++ b/src/app/api/matches/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '../../../lib/prisma';
+
+export async function GET() {
+  try {
+    const matches = await prisma.match.findMany({
+      include: {
+        player1: true,
+        player2: true,
+        winner: true,
+        tournament: true,
+      },
+    });
+
+    return NextResponse.json(matches);
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/api/players/[id]/route.ts
+++ b/src/app/api/players/[id]/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '../../../../lib/prisma';
+
+export async function GET(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  const id = Number(params.id);
+
+  if (Number.isNaN(id)) {
+    return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
+  }
+
+  try {
+    const player = await prisma.player.findUnique({ where: { id } });
+
+    if (!player) {
+      return NextResponse.json({ error: 'Player not found' }, { status: 404 });
+    }
+
+    return NextResponse.json(player);
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/api/players/route.ts
+++ b/src/app/api/players/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '../../../lib/prisma';
+
+export async function GET() {
+  try {
+    const players = await prisma.player.findMany();
+    return NextResponse.json(players);
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/api/tournaments/[id]/route.ts
+++ b/src/app/api/tournaments/[id]/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '../../../../lib/prisma';
+
+export async function GET(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  const id = Number(params.id);
+
+  if (Number.isNaN(id)) {
+    return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
+  }
+
+  try {
+    const tournament = await prisma.tournament.findUnique({ where: { id } });
+
+    if (!tournament) {
+      return NextResponse.json({ error: 'Tournament not found' }, { status: 404 });
+    }
+
+    return NextResponse.json(tournament);
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/api/tournaments/route.ts
+++ b/src/app/api/tournaments/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '../../../lib/prisma';
+
+export async function GET() {
+  try {
+    const tournaments = await prisma.tournament.findMany();
+    return NextResponse.json(tournaments);
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,12 @@
+import { PrismaClient } from '@prisma/client';
+
+// Ensure the PrismaClient is instantiated only once in development to
+// prevent exhausting database connections due to hot reloading.
+const globalForPrisma = global as unknown as { prisma: PrismaClient | undefined };
+
+export const prisma =
+  globalForPrisma.prisma ||
+  new PrismaClient({ log: ['query', 'info', 'warn', 'error'] });
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;
+


### PR DESCRIPTION
## Summary
- replace pages/api routes with App Router routes
- add GET routes for players, tournaments and matches under `app/api`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841975661ec832cb9700f3a4e193a4b