### PR TITLE
Add seed script

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This project was initialized manually with **Next.js 15**, **TypeScript**, **Tai
 - `npm run start` - Run production build
 - `npm run lint` - Lint files using ESLint
 - `npm run test` - Run unit tests with Jest
+- `npm run seed` - Seed the database with 128 mock players and first-round matches
 
 ## Setup
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "jest"
+    "test": "jest",
+    "seed": "ts-node prisma/seed.ts"
   },
   "dependencies": {
     "@prisma/client": "^6.9.0",
@@ -32,5 +33,8 @@
     "ts-jest": "^29.0.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.4.0"
+  },
+  "prisma": {
+    "seed": "ts-node prisma/seed.ts"
   }
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,51 @@
+import { PrismaClient, Round } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  // create 128 players with mock data
+  const players = [] as { id: number }[];
+  for (let i = 1; i <= 128; i++) {
+    const player = await prisma.player.create({
+      data: {
+        name: `Player ${i}`,
+        country: `Country ${i}`,
+        ranking: i,
+      },
+    });
+    players.push(player);
+  }
+
+  // create a single tournament
+  const tournament = await prisma.tournament.create({
+    data: {
+      name: 'Mock Championship',
+      year: 2024,
+      startDate: new Date('2024-01-01'),
+      endDate: new Date('2024-01-14'),
+      location: 'Test Arena',
+    },
+  });
+
+  // create 64 matches for the first round (1 vs 128, 2 vs 127, ...)
+  for (let i = 0; i < 64; i++) {
+    await prisma.match.create({
+      data: {
+        tournamentId: tournament.id,
+        round: Round.FIRST_ROUND,
+        player1Id: players[i].id,
+        player2Id: players[127 - i].id,
+        matchDate: new Date('2024-01-02'),
+      },
+    });
+  }
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Summary
- add a Prisma seed script that populates Players, Tournament and Matches
- expose `npm run seed` in package.json
- document seed script in README
- update seed script for 128 players

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841a798ee6c832cb910d990631c5f78