### PR TITLE
Add tournament bracket page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+.next/
+.env
+*.log
+prisma/dev.db

--- a/src/app/components/Bracket.tsx
+++ b/src/app/components/Bracket.tsx
@@ -1,0 +1,77 @@
+import { Round } from '@prisma/client';
+import { prisma } from '../../lib/prisma';
+
+const roundOrder: Round[] = [
+  Round.FIRST_ROUND,
+  Round.SECOND_ROUND,
+  Round.THIRD_ROUND,
+  Round.FOURTH_ROUND,
+  Round.QUARTERFINAL,
+  Round.SEMIFINAL,
+  Round.FINAL,
+];
+
+const roundLabels: Record<Round, string> = {
+  [Round.FIRST_ROUND]: '1ª Rodada',
+  [Round.SECOND_ROUND]: '2ª Rodada',
+  [Round.THIRD_ROUND]: '3ª Rodada',
+  [Round.FOURTH_ROUND]: '4ª Rodada',
+  [Round.QUARTERFINAL]: 'Quartas',
+  [Round.SEMIFINAL]: 'Semifinal',
+  [Round.FINAL]: 'Final',
+};
+
+export default async function Bracket() {
+  const matches = await prisma.match.findMany({
+    include: {
+      player1: true,
+      player2: true,
+      winner: true,
+    },
+    orderBy: { id: 'asc' },
+  });
+
+  const matchesByRound: Record<Round, typeof matches> = {
+    [Round.FIRST_ROUND]: [],
+    [Round.SECOND_ROUND]: [],
+    [Round.THIRD_ROUND]: [],
+    [Round.FOURTH_ROUND]: [],
+    [Round.QUARTERFINAL]: [],
+    [Round.SEMIFINAL]: [],
+    [Round.FINAL]: [],
+  };
+
+  for (const match of matches) {
+    matchesByRound[match.round].push(match);
+  }
+
+  return (
+    <div className="overflow-x-auto py-4">
+      <div className="flex space-x-4">
+        {roundOrder.map((round) => (
+          <div key={round} className="min-w-56">
+            <h2 className="text-center font-semibold mb-4">
+              {roundLabels[round]}
+            </h2>
+            <div className="space-y-4">
+              {matchesByRound[round].map((m) => (
+                <div
+                  key={m.id}
+                  className="bg-white border rounded p-2 shadow text-sm"
+                >
+                  <div className="font-medium">{m.player1.name}</div>
+                  <div className="font-medium">{m.player2.name}</div>
+                  {m.winner && (
+                    <div className="text-green-600 mt-1">
+                      Vencedor: {m.winner.name}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import './globals.css';
+import '../styles/globals.css';
 import type { ReactNode } from 'react';
 
 export default function RootLayout({ children }: { children: ReactNode }) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,10 @@
+import Bracket from './components/Bracket';
+
 export default function Home() {
   return (
-    <main className="flex min-h-screen items-center justify-center">
-      <h1 className="text-2xl font-bold">Tennis Tournament</h1>
+    <main className="min-h-screen p-4">
+      <h1 className="text-2xl font-bold text-center mb-6">Tennis Tournament</h1>
+      <Bracket />
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- show matches grouped by rounds
- style rounds with Tailwind columns
- include bracket component on home page
- fix global CSS path and add .gitignore

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841aa8074bc832cbbd22d4b5d7fdd2e