### PR TITLE
Remove Prisma enum from schema

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -29,21 +29,12 @@ model Tournament {
   matches   Match[]
 }
 
-enum Round {
-  FIRST_ROUND
-  SECOND_ROUND
-  THIRD_ROUND
-  FOURTH_ROUND
-  QUARTERFINAL
-  SEMIFINAL
-  FINAL
-}
 
 model Match {
   id            Int        @id @default(autoincrement())
   tournament    Tournament @relation(fields: [tournamentId], references: [id])
   tournamentId  Int
-  round         Round
+  round         String
   player1       Player     @relation("Player1", fields: [player1Id], references: [id])
   player1Id     Int
   player2       Player     @relation("Player2", fields: [player2Id], references: [id])

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,4 +1,4 @@
-import { PrismaClient, Round } from '@prisma/client';
+import { PrismaClient } from '@prisma/client';
 
 const prisma = new PrismaClient();
 
@@ -32,7 +32,7 @@ async function main() {
     await prisma.match.create({
       data: {
         tournamentId: tournament.id,
-        round: Round.FIRST_ROUND,
+        round: 'FIRST_ROUND',
         player1Id: players[i].id,
         player2Id: players[127 - i].id,
         matchDate: new Date('2024-01-02'),

--- a/src/app/components/Bracket.tsx
+++ b/src/app/components/Bracket.tsx
@@ -1,24 +1,24 @@
-import { Round } from '@prisma/client';
 import { prisma } from '../../lib/prisma';
 
-const roundOrder: Round[] = [
-  Round.FIRST_ROUND,
-  Round.SECOND_ROUND,
-  Round.THIRD_ROUND,
-  Round.FOURTH_ROUND,
-  Round.QUARTERFINAL,
-  Round.SEMIFINAL,
-  Round.FINAL,
-];
+export const roundOrder = [
+  'FIRST_ROUND',
+  'SECOND_ROUND',
+  'THIRD_ROUND',
+  'FOURTH_ROUND',
+  'QUARTERFINAL',
+  'SEMIFINAL',
+  'FINAL',
+] as const;
+export type Round = (typeof roundOrder)[number];
 
 const roundLabels: Record<Round, string> = {
-  [Round.FIRST_ROUND]: '1ª Rodada',
-  [Round.SECOND_ROUND]: '2ª Rodada',
-  [Round.THIRD_ROUND]: '3ª Rodada',
-  [Round.FOURTH_ROUND]: '4ª Rodada',
-  [Round.QUARTERFINAL]: 'Quartas',
-  [Round.SEMIFINAL]: 'Semifinal',
-  [Round.FINAL]: 'Final',
+  FIRST_ROUND: '1ª Rodada',
+  SECOND_ROUND: '2ª Rodada',
+  THIRD_ROUND: '3ª Rodada',
+  FOURTH_ROUND: '4ª Rodada',
+  QUARTERFINAL: 'Quartas',
+  SEMIFINAL: 'Semifinal',
+  FINAL: 'Final',
 };
 
 export default async function Bracket() {
@@ -32,17 +32,17 @@ export default async function Bracket() {
   });
 
   const matchesByRound: Record<Round, typeof matches> = {
-    [Round.FIRST_ROUND]: [],
-    [Round.SECOND_ROUND]: [],
-    [Round.THIRD_ROUND]: [],
-    [Round.FOURTH_ROUND]: [],
-    [Round.QUARTERFINAL]: [],
-    [Round.SEMIFINAL]: [],
-    [Round.FINAL]: [],
+    FIRST_ROUND: [],
+    SECOND_ROUND: [],
+    THIRD_ROUND: [],
+    FOURTH_ROUND: [],
+    QUARTERFINAL: [],
+    SEMIFINAL: [],
+    FINAL: [],
   };
 
   for (const match of matches) {
-    matchesByRound[match.round].push(match);
+    matchesByRound[match.round as Round].push(match);
   }
 
   return (


### PR DESCRIPTION
## Summary
- avoid Prisma enums due to SQLite limitation
- adapt seed script and Bracket component

## Testing
- `npm install`
- `npx prisma generate` *(fails: 403 Forbidden)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841af09ff78832c9204669481d59327